### PR TITLE
Parse_id excludes file extension

### DIFF
--- a/src/routes.rs
+++ b/src/routes.rs
@@ -19,7 +19,7 @@ use std::{fs, path::PathBuf};
 /// Parses an ID
 fn parse_id(id: &str) -> Result<i32, HttpResponse> {
     // Remove any file extension from id
-    let id = id.split('.').next().unwrap();
+    let id = id.split('.').next().unwrap_or_default();
 
     match i32::from_str_radix(id, 36) {
         Ok(id) => Ok(id),

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -18,6 +18,9 @@ use std::{fs, path::PathBuf};
 
 /// Parses an ID
 fn parse_id(id: &str) -> Result<i32, HttpResponse> {
+    // Remove any file extension from id
+    let id = id.split('.').next().unwrap();
+
     match i32::from_str_radix(id, 36) {
         Ok(id) => Ok(id),
         Err(_) => Err(HttpResponse::BadRequest().body("Invalid ID")),


### PR DESCRIPTION
This PR allows Parse_id to find the correct id when there's an extension included with the request.

Example: I want to embed an mp4 into discord. So i request `a1b2c3.mp4`, but the server returns `Invalid ID` because of the extension. With this change the server responds with the correct file
